### PR TITLE
Add SoF patient/*.read and launch scopes

### DIFF
--- a/dev/config/keycloak/import/ltt-realm.json
+++ b/dev/config/keycloak/import/ltt-realm.json
@@ -144,7 +144,10 @@
        "optionalClientScopes": [
          "address",
          "phone",
+         "launch",
          "offline_access",
+         "online_access",
+         "patient/*.read",
          "microprofile-jwt"
        ]
      },
@@ -306,6 +309,16 @@
       "protocol": "openid-connect",
       "attributes": {
         "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "b1a46bef-7912-4ea4-acd9-b06c07ee8b34",
+      "name": "online_access",
+      "description": "OpenID Connect built-in scope: online_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${onlineAccessScopeConsentText}",
         "display.on.consent.screen": "true"
       }
     },
@@ -746,6 +759,9 @@
   ],
   "defaultOptionalClientScopes": [
     "offline_access",
+    "online_access",
+    "launch",
+    "patient/*.read",
     "address",
     "phone",
     "microprofile-jwt"

--- a/dev/config/keycloak/import/ltt-realm.json
+++ b/dev/config/keycloak/import/ltt-realm.json
@@ -352,6 +352,28 @@
       ]
     },
     {
+      "id": "18295a0a-daaf-448d-8793-cb39b36703cd",
+      "_comment": "http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/",
+      "name": "patient/*.read",
+      "description": "SoF: Read all data for launch patient",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "78ad99cd-c336-42ed-a55a-ddbe6119c928",
+      "_comment": "http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/",
+      "name": "launch",
+      "description": "SoF: launch token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
       "id": "0e57bc1e-d2a9-4580-ad49-863c2ce868ac",
       "name": "web-origins",
       "description": "OpenID Connect scope for add allowed web origins to the access token",


### PR DESCRIPTION
Add scopes for SoF access

Per [Slack](https://cirg.slack.com/archives/C025H0S1UKB/p1706915656250559?thread_ts=1706127875.711299&cid=C025H0S1UKB)
> I think we just need to add the (default) SoF-specific scopes into keycloak. we've done similar for cosri:
> https://github.com/uwcirg/cosri-environments/blob/master/base/freestanding/femr/config/keycloak/realm-data.json#L3213-L3234