### PR TITLE
Add test users to ltt realm

### DIFF
--- a/dev/config/keycloak/import/ltt-realm.json
+++ b/dev/config/keycloak/import/ltt-realm.json
@@ -51,6 +51,19 @@
     "clientRole": false,
     "containerId": "25facb13-fdb5-46cd-b66d-fa9305652f1a"
   },
+  "roles": {
+    "realm": [
+      {
+        "id": "5614c921-f5f1-44b8-a04a-fc3b06dec10f",
+        "name": "staff-realm-role",
+        "description": "realm-specific staff role",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "25facb13-fdb5-46cd-b66d-fa9305652f1a",
+        "attributes": {}
+      }
+    ]
+  },
   "requiredCredentials": [
     "password"
   ],

--- a/dev/config/keycloak/import/ltt-users-0.json
+++ b/dev/config/keycloak/import/ltt-users-0.json
@@ -1,0 +1,33 @@
+{
+  "realm": "ltt",
+  "users": [
+    {
+      "id": "ltt-test-user",
+      "createdTimestamp": 1709134971000,
+      "username": "test",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": true,
+      "firstName": "FirstName",
+      "lastName": "LastName",
+      "email": "test@test.test",
+      "credentials": [
+        {
+          "id": "ltt-test-user-password",
+          "type": "password",
+          "createdDate": 1709134971000,
+          "secretData": "{\"value\":\"7Vmr6+Io+gJJrH+EOcmOJXshJ0tMI5x0rQ1wkCYgSCA=\",\"salt\":\"LR0DSOi5850zn9tNFYS1uw==\",\"additionalParameters\":{}}",
+          "userLabel": "test user password is set to \"test\"",
+          "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-ltt"
+      ],
+      "notBefore": 0,
+      "groups": []
+    }
+  ]
+}

--- a/dev/config/keycloak/import/ltt-users-0.json
+++ b/dev/config/keycloak/import/ltt-users-0.json
@@ -28,6 +28,34 @@
       ],
       "notBefore": 0,
       "groups": []
+    },
+    {
+      "id": "ltt-staff-user",
+      "createdTimestamp": 1709134971000,
+      "username": "staff",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": true,
+      "firstName": "Test",
+      "lastName": "Staff",
+      "email": "stafftest@test.test",
+      "credentials": [
+        {
+          "id": "ltt-staff-user-password",
+          "type": "password",
+          "createdDate": 1709134971000,
+          "secretData" : "{\"value\":\"86AHPCF6rK9rndTfdST1Ijn4XQ6xC4/uoa3Q0S0O5nE=\",\"salt\":\"veo4rv2pmuiMhWcJgJmw7A==\",\"additionalParameters\":{}}",
+          "userLabel": "staff test user password is set to \"staff\"",
+          "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-ltt"
+      ],
+      "notBefore": 0,
+      "groups": []
     }
   ]
 }

--- a/dev/config/keycloak/import/ltt-users-0.json
+++ b/dev/config/keycloak/import/ltt-users-0.json
@@ -52,7 +52,8 @@
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
-        "default-roles-ltt"
+        "default-roles-ltt",
+        "staff-realm-role"
       ],
       "notBefore": 0,
       "groups": []


### PR DESCRIPTION
- Add test users to ltt realm
  - ignores realm-level username/password requirements
  - test user credentials: `test`/`test`
  - test staff credentials: `staff`/`staff`
- add staff role to ltt realm
