### PR TITLE
Remove `cpro` subdomain from cpro service

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     image: ${DOCKER_REPOSITORY-glcr.cirg.uw.edu/svn/dhair2}:${CPRO_IMAGE_TAG:-master}
     environment:
       DATABASE_URL: ${DATABASE_URL:-mysql://mysql:cPR0health@CIRG@mysql:3306/cpro}
-      SERVER_NAME: cpro.${BASE_DOMAIN}
+      SERVER_NAME: ${BASE_DOMAIN}
       HTTPS: "true"
       INSTANCE_ID: inform
       SHL_MANAGER_URL: https://shl-creator.${BASE_DOMAIN}/share
@@ -38,7 +38,7 @@ services:
     labels:
       - traefik.enable=true
       # Traefik will route requests with Host matching the SERVER_NAME environment variable (see .env)
-      - traefik.http.routers.cpro-${COMPOSE_PROJECT_NAME}.rule=Host(`cpro.${BASE_DOMAIN}`)
+      - traefik.http.routers.cpro-${COMPOSE_PROJECT_NAME}.rule=Host(`${BASE_DOMAIN}`)
 
       - traefik.http.routers.cpro-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
       - traefik.http.routers.cpro-${COMPOSE_PROJECT_NAME}.tls=true


### PR DESCRIPTION
Remove `cpro` subdomain from cpro service; forward requests from base domain to cpro

eg `cpro.letstalktech.stg.cirg.uw.edu` vs `letstalktech.stg.cirg.uw.edu`