### PR TITLE
update project display name

### DIFF
--- a/dev/config/keycloak/import/ltt-realm.json
+++ b/dev/config/keycloak/import/ltt-realm.json
@@ -1,6 +1,7 @@
 {
   "id": "25facb13-fdb5-46cd-b66d-fa9305652f1a",
   "realm": "ltt",
+  "displayName": "Let's Talk Tech",
   "notBefore": 0,
   "defaultSignatureAlgorithm": "RS256",
   "revokeRefreshToken": false,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187436665
Per feedback from Clara:
"In the password reset email text, can we please call it Let’s Talk Tech instead of Ltt, as below, since they’re getting an email from an unfamiliar CIRG sender and have not encountered that Ltt acronym?"

Changing the display name seems to help.  This is what I saw when testing in my instance:
![Email](https://github.com/uwcirg/ltt-environments/assets/12942714/750e35e2-1f75-4232-a328-5cbd068f564c)




