### PR TITLE
Docker compose fixups

### DIFF
--- a/base/docker-compose.yaml
+++ b/base/docker-compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   cpro:
-    image: ${DOCKER_REPOSITORY-glcr.cirg.uw.edu/svn/dhair2}:${CPRO_IMAGE_TAG:-master}
+    image: ${DOCKER_REPOSITORY-glcr.cirg.uw.edu/svn/dhair2}:${CPRO_IMAGE_TAG:-master-php5}
     environment:
       DATABASE_URL: ${DATABASE_URL:-mysql://mysql:cPR0health@CIRG@mysql:3306/cpro}
       SERVER_NAME: ${BASE_DOMAIN}

--- a/base/docker-compose.yaml
+++ b/base/docker-compose.yaml
@@ -28,8 +28,6 @@ services:
        cake less generate &&
        cake speech_generate &&
        apache2-foreground'
-    depends_on:
-      - mysql
     volumes:
       - secure-data:/var/www/html/app/securedata
       - tmp-data:/var/www/html/app/tmp
@@ -108,8 +106,6 @@ services:
         - --quiet
         - http://localhost:8080/actuator/health
       start_period: 2m
-    depends_on:
-      - db
     networks:
       internal:
         aliases:
@@ -159,8 +155,6 @@ services:
     volumes:
       - ./config/keycloak/import/:/opt/keycloak/data/import:ro
       - ./config/keycloak/themes/:/opt/keycloak/themes:ro
-    depends_on:
-      - db
     networks:
       - ingress
       - internal
@@ -189,8 +183,6 @@ services:
       - traefik.http.middlewares.fhir-auth-${COMPOSE_PROJECT_NAME}-cors.headers.accessControlAllowMethods=HEAD,GET,OPTIONS,PATCH,POST,PUT,DELETE
       - traefik.http.middlewares.fhir-auth-${COMPOSE_PROJECT_NAME}-cors.headers.accessControlAllowHeaders=Authorization,Origin,Content-Type,Accept,Cache-Control
       - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.middlewares=fhir-auth-${COMPOSE_PROJECT_NAME}-cors
-    depends_on:
-      - fhir
     networks:
       - ingress
       - internal

--- a/dev/README.md
+++ b/dev/README.md
@@ -17,4 +17,4 @@ Modify the `.env` file as necessary. Lines that are not commented-out are requir
 ## Deploy
 To pull the latest configured docker images, and re-deploy services as necessary, run the following command:
 
-    docker-compose pull && docker-compose up --detach
+    docker compose pull && docker compose up --detach

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
       service: cpro
     env_file:
       - cpro.env
+    depends_on:
+      - mysql
   mysql:
     extends:
       file: ../base/docker-compose.yaml
@@ -20,6 +22,8 @@ services:
     extends:
       file: ../base/docker-compose.yaml
       service: fhir
+    depends_on:
+      - db
     # expose HAPI to internet
     networks:
       ingress:
@@ -35,11 +39,15 @@ services:
       service: keycloak
     env_file:
       - keycloak.env
+    depends_on:
+      - db
 
   fhir-auth:
     extends:
       file: ../base/docker-compose.yaml
       service: fhir-auth
+    depends_on:
+      - fhir
 
   shl-creator:
     extends:

--- a/prod/README.md
+++ b/prod/README.md
@@ -17,4 +17,4 @@ Modify the `.env` file as necessary. Lines that are not commented-out are requir
 ## Deploy
 To pull the latest configured docker images, and re-deploy services as necessary, run the following command:
 
-    docker-compose pull && docker-compose up --detach
+    docker compose pull && docker compose up --detach

--- a/prod/docker-compose.yaml
+++ b/prod/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
       service: cpro
     env_file:
       - cpro.env
+    depends_on:
+      - mysql
   mysql:
     extends:
       file: ../base/docker-compose.yaml
@@ -20,6 +22,8 @@ services:
     extends:
       file: ../base/docker-compose.yaml
       service: fhir
+    depends_on:
+      - db
 
   keycloak:
     extends:
@@ -27,11 +31,15 @@ services:
       service: keycloak
     env_file:
       - keycloak.env
+    depends_on:
+      - db
 
   fhir-auth:
     extends:
       file: ../base/docker-compose.yaml
       service: fhir-auth
+    depends_on:
+      - fhir
 
   shl-creator:
     extends:


### PR DESCRIPTION
- Move `depends_on` to dev and prod overrides (for docker compose v1)
  - Fixes `services with 'depends_on' cannot be extended`
- Update docs
